### PR TITLE
use exec in plugin shell script

### DIFF
--- a/java/src/main/resources/run.sh
+++ b/java/src/main/resources/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-
-/usr/local/bin/java -jar ${project.build.finalName}.jar
+# For the time being use exec in order to cope with hashicorp's go-plugin failure to kill child processes.
+# See https://github.com/hashicorp/go-plugin/issues/136
+exec /usr/local/bin/java -jar ${project.build.finalName}.jar


### PR DESCRIPTION
use exec in the java plugin run.sh script so that the go-plugin process stop signal goes to the java process